### PR TITLE
Fix typo of conditional types

### DIFF
--- a/.yarn/versions/45d5be87.yml
+++ b/.yarn/versions/45d5be87.yml
@@ -1,0 +1,2 @@
+releases:
+  "@cometjs/core": minor

--- a/packages/core/src/conditional.ts
+++ b/packages/core/src/conditional.ts
@@ -7,11 +7,11 @@ export type Falsy = (
   | 0
 );
 
-export type Trusthy<T = InferrableAny> = Exclude<T, Falsy>;
+export type Truhty<T = InferrableAny> = Exclude<T, Falsy>;
 
-export type Conditional<T> = Trusthy<T> | Falsy;
+export type Conditional<T> = Truhty<T> | Falsy;
 
-export function isTrusthy<T>(condition: Conditional<T>): condition is Trusthy<T> {
+export function isTruhty<T>(condition: Conditional<T>): condition is Truhty<T> {
   return Boolean(condition);
 }
 


### PR DESCRIPTION
`Trusthy`(X) `Truthy`(O)
